### PR TITLE
Fix TypeError

### DIFF
--- a/tcc
+++ b/tcc
@@ -113,6 +113,7 @@ for key, value in body_json.items():
             word = replace_chars(k['word'].encode('utf-8'))
             result += '{0}{1}'.format(joint, word)
 
-result += body_json['lastJoint'].encode('utf-8')
+result += body_json['lastJoint']
+result.encode('utf-8')
 
 print(result)


### PR DESCRIPTION
Fixes:
```
$ ./tcc this is a test       
Traceback (most recent call last):
  File "./tcc", line 116, in <module>
    result += body_json['lastJoint'].encode('utf-8')
TypeError: can only concatenate str (not "bytes") to str
```